### PR TITLE
Simplify o2locktop options, update usage and add code to check input parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ You can get the maximal wait time per DLM lock, this helps you identify which ho
 
 Login one node of the OCFS2 cluster, get the o2locktop scripts from https://github.com/ganghe/o2locktop.  
 Make sure passwordless SSH access between the nodes is set up, and Python interpreter is installed.  
-Launch o2locktop script via the command line, e.g. "o2locktop -n node1:/mnt/shared -n node2 -n node3".  
+Launch o2locktop script via the command line, e.g. "o2locktop -n node1 -n node2 -n node3 /mnt/shared".  
+Type "d" to diplay DLM lock statistics for each node.
 Type "Ctrl+C" or "q" to end o2locltop process.  
 For more information, please see o2locktop help via the command line "o2locktop --help".
 
@@ -45,8 +46,6 @@ Since OCFS2 file system statistics in kernel records the relevant data when appl
 
 ## To do list
 
-Add program version.  
 Add switch to hide/display system file inodes.  
-Add command option to specify how many the inode items to display.  
 Replay o2locktop log file.  
 Simplify o2locktop options, make it more easier to use.  

--- a/keyboard.py
+++ b/keyboard.py
@@ -49,7 +49,7 @@ class Keyboard():
                                     'what':'1'})
                 break
 
-            if c == '1':
+            if c == 'd':
                 printer_queue.put({'msg_type':'kb_hit',
                                     'what':'detial'})
 

--- a/o2locktop
+++ b/o2locktop
@@ -12,99 +12,75 @@ import argparse
 import multiprocessing
 import os
 
+VERSION = "o2locktop 1.0.0"
 
 def parse_args():
     description=""
     usage = \
 """
-o2locktop is a tool used to tell which inode is most busy it works like linux top command
-This tool supports both local and remote monitoring your filesystem
+Usage: o2locktop [OPTIONS] MOUNTPOINT
+       o2locktop -h|--help
+       o2locktop -V|--version
+[OPTIONS] can be:
+       -o log file path
+       -n other node IP/hostname
+       -l number of lines to display
 
-REMOTE MODE:
-  o2locktop [-o LOG_FILE_PATH] [-l LINES_TO_SHOW] -n <NODE_IP>:<MOUNT_POINT> -n <NODE_IP> 
+Monitor the MOUNTPOINT OCFS2 DLM lock statistics. 
+Make sure passwordless SSH access between the nodes is set up.
+Launch o2locktop script like the below command line, 
+e.g. remote mode: "o2locktop -n node1 -n node2 -n node3 /mnt/shared".
+     local mode : "o2locktop /mnt/shared".
 
-LOCAL MODE:
-  o2locktop [-o LOG_FILE_PATH] [-l LINES_TO_SHOW] <MOUNT_POINT>
+Controls: 
+Type "d" to diplay DLM lock statistics for each node.
+Type "Ctrl+C" or "q" to exit o2locltop process.
 
-SHOW VERSION
-  o2locktop -V|-v|--version
-
-Running in remote mode allows users run out of or inside of your cluster.
-Use -n to specify the remote ip or hostname used for ssh
-
-  1. copy ssh pub key to remote host
-
-    (1). ssh-copy-id root@192.168.1.1
-
-    (2). ssh-copy-id root@192.168.1.2
-
-  2. run o2locktop and use ":" to specify a combination of a node and a mount point on it
-
-    o2locktop  -o /path/to/test.log -n 192.168.1.1 -n 192.168.1.2:/mnt/ocfs2
-
-o2locktop also supports local mode, like the following
-
-    o2locktop -o /path/to/test.log /mnt/ocfs2
-
-NOTICE:
-
-1. When running, press '1' to see what is happening on each node :)
-
-2. When running, Press 'q' or 'Ctrl-c' to exit gracefully
-
-MORE:
-
-Now, o2locktop can only shows the inode number of the busy files, you should help yourself to
-find the path corresponding to the inode number.
+Suggestion:
+Please read the README.md file for more information.
 """
-    parser = argparse.ArgumentParser(description=description, usage=usage, prog='o2locktop')
+    parser = argparse.ArgumentParser(description=description, usage=None, prog='o2locktop', add_help=False)
     parser.add_argument('-n', metavar='host',
                         dest='host_list', action='append',
                         help='node address used for ssh')
 
     parser.add_argument('-o', metavar='log', dest='log',
-                        action='store', help='log path')
+                        action='store',
+                        help='log path')
 
     parser.add_argument('-l', metavar='display length', dest='display_len', 
                         default=10,type=int,
-                        action='store', help='the line of the lock to show, default is 10')
+                        action='store',
+                        help='the line of the lock to show, default is 10')
 
-    parser.add_argument('-V','-v','--version',action="store_true", 
+    parser.add_argument('-V','--version',action="store_true", 
                         help='current version of o2locktop')
 
-    parser.add_argument('-d','--debug',action="store_true", 
+    parser.add_argument('-d','--debug',action="store_true",
                         help='show all the inode,include the system inode number')
 
-    parser.add_argument('local_mount', nargs='?',
-                        help='local mount point like /mnt')
+    parser.add_argument('mount_point', nargs='?',
+                        help='mount point like /mnt')
 
+    parser.add_argument('-h','--help',action="store_true", 
+                        help='show this help message and exit')
 
     args = parser.parse_args()
-    mount_node, mount_point = None, None
 
     node_list = []
     met_colon = False
     if args.version:
-        print("o2locktop 1.0.0")
+        print(VERSION)
+        sys.exit(0)
+    if args.help:
+        print(usage)
         sys.exit(0)
     if args.host_list:
-        for i in args.host_list:
-
-            if ":" in i:
-                if met_colon:
-                    util.eprint("Respecify mount point: " + i)
-                    sys.exit(0)
-                try:
-                    mount_node, mount_point = i.split(':')
-                    node_list.append(mount_node)
-                except:
-                    util.eprint("Error parameter: " + i)
-                    sys.exit(0)
-            else:
-                node_list.append(i)
-        if args.local_mount:
-            util.eprint("Local mount point is not needed")
+        if not args.mount_point:
+            util.eprint("mount point is needed")
             sys.exit(0)
+        for i in args.host_list:
+            node_list.append(i)
         if args.display_len <= 0:
             util.eprint("The length of the line to show must be greater than 0")
             sys.exit(0)
@@ -114,18 +90,20 @@ find the path corresponding to the inode number.
 
         return {
                 "mode":"remote",
-                "mount_node" : mount_node,
-                "mount_point" : mount_point,
+                "mount_node" : node_list[0],
+                "mount_point" : args.mount_point,
                 "node_list" : node_list,
                 "log" : args.log,
                 "display_len" : args.display_len,
                 "debug" : args.debug
                 }
-    elif args.local_mount:
-        mount_point = args.local_mount
+    else:
+        if not args.mount_point:
+            util.eprint("mount point is needed")
+            sys.exit(0)
         return {
                 "mode":"local",
-                "mount_point" : args.local_mount,
+                "mount_point" : args.mount_point,
                 "log" : args.log,
                 "display_len" : args.display_len,
                 "debug" : args.debug

--- a/o2locktop
+++ b/o2locktop
@@ -112,20 +112,41 @@ Please read the README.md file for more information.
     parser.print_help()
     sys.exit(0)
 
+def connection_test(nodes,mount_point):
+    assert(nodes != None and len(nodes) > 0)
+    uuid = util.get_dlm_lockspace_mp(nodes[0], mount_point)    
+    if not uuid:
+        util.eprint("can't find the mount point: {}, please cheack and retry".format(mount_point))
+        sys.exit(0)
+    for node in nodes[1:]:
+        if uuid != util.get_dlm_lockspace_mp(node, mount_point):
+            util.eprint("can't find the shared storage in the cluster")
+            util.eprint("check if the node in the command line has input errors")
+            sys.exit(0) 
+
+def local_test(mount_point):
+    uuid = util.get_dlm_lockspace_mp(None, mount_point)    
+    if not uuid:
+        util.eprint("can't find the mount point: {}, please cheack and retry".format(mount_point))
+        sys.exit(0)
+
 def main():
     args = parse_args()
     log = args["log"]
     display_len = args["display_len"] 
     debug = args["debug"]
+    
 
     if args['mode'] == "remote":
-        nodes = args["node_list"]
         mount_host, mount_point = args["mount_node"], args["mount_point"]
+        nodes = args["node_list"]
+        connection_test(nodes, mount_point)
         lock_space_str = util.get_dlm_lockspace_mp(mount_host, mount_point)
         max_sys_inode_num = util.get_dlm_lockspace_max_sys_inode_number(mount_host, mount_point)
         mount_info = ':'.join([mount_host, mount_point])
     elif args['mode'] == "local":
         mount_point = args["mount_point"]
+        local_test(mount_point)
         lock_space_str = util.get_dlm_lockspace_mp(None, mount_point)
         max_sys_inode_num = util.get_dlm_lockspace_max_sys_inode_number(None, mount_point)
         mount_info = mount_point

--- a/util.py
+++ b/util.py
@@ -18,7 +18,6 @@ def now():
 def sleep(interval):
     return time.sleep(interval)
 
-
 def uname_r(ip=None):
     prefix = "ssh root@{0} ".format(ip) if ip else ""
     cmd = "uname -r"
@@ -156,11 +155,15 @@ def get_dlm_lockspace_mp(ip, mount_point):
     return None
 
 def _trans_uuid(uuid):
+    if not uuid:
+        return None
     uuid = uuid.lower()
     return "{}-{}-{}-{}-{}".format(uuid[:8],uuid[8:12],uuid[12:16],uuid[16:20],uuid[20:])
 
 def get_dlm_lockspace_max_sys_inode_number(ip, mount_point):
     uuid = _trans_uuid(get_dlm_lockspace_mp(ip, mount_point))
+    if not uuid:
+        eprint("can't find the mount point: {}, please cheach and retry".format(mount_point))
     cmd = "blkid  | grep {}".format(uuid)
     output = os.popen(cmd)
     output = output.readlines()


### PR DESCRIPTION
Separating node and mount point makes it easier to use.(from "o2locktop -n node1:/mnt/shared -n node2" to "o2locktop -n node1 -n node2 /mnt/shared")
Use the "d" button on the display interface to display detailed information instead of the original "1" button.
Disable the automatically generated help information from argparse module, using custom help information

Check the input parameters. If the input mount point cannot be found, the program will print a prompt message and exit normally without causing an exception that may affect other processes in the program.

If the program unable to connect to a node in the cluster(according to the input), or the connection has been established, but the shared storage disk is not found, the prompt message will also be printed and the program will be terminated normally.