### PR TITLE
Change the display of the error output

### DIFF
--- a/o2locktop
+++ b/o2locktop
@@ -75,18 +75,19 @@ Please read the README.md file for more information.
     if args.help:
         print(usage)
         sys.exit(0)
+    if args.display_len <= 0:
+        util.eprint("o2locktop: error: The length of the line to show must be greater than 0")
+        sys.exit(0)
+    if args.display_len > 50:
+        util.eprint("o2locktop: error: The length of the line to show must be less than 50")
+        sys.exit(0)
     if args.host_list:
         if not args.mount_point:
-            util.eprint("mount point is needed")
+            util.eprint("o2locktop: error: ocfs2 mount point is needed")
+            print(usage)
             sys.exit(0)
         for i in args.host_list:
             node_list.append(i)
-        if args.display_len <= 0:
-            util.eprint("The length of the line to show must be greater than 0")
-            sys.exit(0)
-        if args.display_len > 50:
-            util.eprint("The length of the line to show must be less than 50")
-            sys.exit(0)
 
         return {
                 "mode":"remote",
@@ -99,7 +100,8 @@ Please read the README.md file for more information.
                 }
     else:
         if not args.mount_point:
-            util.eprint("mount point is needed")
+            util.eprint("o2locktop: error: ocfs2 mount point is needed")
+            print(usage)
             sys.exit(0)
         return {
                 "mode":"local",
@@ -116,18 +118,18 @@ def connection_test(nodes,mount_point):
     assert(nodes != None and len(nodes) > 0)
     uuid = util.get_dlm_lockspace_mp(nodes[0], mount_point)    
     if not uuid:
-        util.eprint("can't find the mount point: {}, please cheack and retry".format(mount_point))
+        util.eprint("o2locktop: error: can't find the mount point: {}, please cheack and retry".format(mount_point))
         sys.exit(0)
     for node in nodes[1:]:
         if uuid != util.get_dlm_lockspace_mp(node, mount_point):
-            util.eprint("can't find the shared storage in the cluster")
-            util.eprint("check if the node in the command line has input errors")
+            util.eprint("o2locktop: error: can't find the shared storage in the cluster, "\
+                                    "check if the node in the command line has input errors")
             sys.exit(0) 
 
 def local_test(mount_point):
     uuid = util.get_dlm_lockspace_mp(None, mount_point)    
     if not uuid:
-        util.eprint("can't find the mount point: {}, please cheack and retry".format(mount_point))
+        util.eprint("o2locktop: error: can't find the mount point: {}, please cheack and retry".format(mount_point))
         sys.exit(0)
 
 def main():

--- a/util.py
+++ b/util.py
@@ -163,7 +163,7 @@ def _trans_uuid(uuid):
 def get_dlm_lockspace_max_sys_inode_number(ip, mount_point):
     uuid = _trans_uuid(get_dlm_lockspace_mp(ip, mount_point))
     if not uuid:
-        eprint("can't find the mount point: {}, please cheach and retry".format(mount_point))
+        eprint("o2locktop: error: can't find the mount point: {}, please cheach and retry".format(mount_point))
     cmd = "blkid  | grep {}".format(uuid)
     output = os.popen(cmd)
     output = output.readlines()


### PR DESCRIPTION
The usage prompt is given for the simple execution of the o2locktop command without adding any parameters. The content is consistent with the "--help"result.

Change the output of the parameter error, consistent with the module used in the program