### PR TITLE
Add dynamic display method

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,8 @@ VERSION = "o2locktop 1.0.0"
 clear = True
 interval = 5
 del_unfreshed_node = False
-
+ROWS = 0
+COLUMNS = 93
 
 pr_locks = 0
 ex_locks = 0

--- a/dlm.py
+++ b/dlm.py
@@ -11,6 +11,7 @@ import util
 import config
 import keyboard
 import time
+import os
 
 # cat  -----  output of one time execution of "cat locking_stat"
                 # one cat contains multiple Shot(es)
@@ -471,6 +472,13 @@ class LockSetGroup():
             self.lock_set_list.append(lock_set)
 
     def get_top_n_key_index(self, n, debug=False):
+        if n == None:
+            rows, cols = os.popen('stty size', 'r').read().split()
+            if int(cols) < config.COLUMNS:
+                n = (int(rows)//2 - 4)
+            else:
+                n = (int(rows) - 6)
+            config.ROWS = n
         if self._sort_flag == False:
             self.lock_set_list.sort(key=lambda x:x.key_index, reverse=True)
         if debug:
@@ -506,6 +514,8 @@ class LockSetGroup():
             lsg_report_simple += lock_set_report['simple'] + '\n'
             lsg_report_detailed += lock_set_report['detailed'] + '\n'
         types = ""
+        lsg_report_simple = lsg_report_simple[:-1]
+        lsg_report_detailed = lsg_report_detailed[:-1]
         for key,value in sorted(self.lock_space._lock_types.items(),key = lambda x:x[1], reverse = True):
             types += "{0} {1}, ".format(key, value)
         types = types[:-2]
@@ -669,7 +679,8 @@ class LockSpace:
             printer_queue.put(
                             {'msg_type':'new_content',
                             'simple':lock_space_report['simple'],
-                            'detailed':lock_space_report['detailed'] }
+                            'detailed':lock_space_report['detailed'],
+                            'rows':config.ROWS}
                             )
             end = time.time()
             new_interval = interval - (end - start)

--- a/o2locktop
+++ b/o2locktop
@@ -50,7 +50,7 @@ Please read the README.md file for more information.
                         help='log path')
 
     parser.add_argument('-l', metavar='display length', dest='display_len', 
-                        default=15,type=int,
+                        type=int,
                         action='store',
                         help='number of lock records to display, the default is 15')
 
@@ -76,11 +76,8 @@ Please read the README.md file for more information.
     if args.help:
         print(usage)
         sys.exit(0)
-    if args.display_len <= 0:
+    if args.display_len != None and args.display_len <= 0:
         util.eprint("o2locktop: error: The length of the line to show must be greater than 0")
-        sys.exit(0)
-    if args.display_len > 50:
-        util.eprint("o2locktop: error: The length of the line to show must be less than 50")
         sys.exit(0)
     if args.host_list:
         if not args.mount_point:

--- a/printer.py
+++ b/printer.py
@@ -20,13 +20,18 @@ class Printer():
             self.log = open(log, 'w')
         self.prelude = None
     @retry(10)
-    def _refresh(self):
+    def _refresh(self,rows):
         if self.content:
             if(config.clear):
                 util.clear_screen()
             if self.prelude:
                 print(self.prelude)
-            print(self.content[self.display_mode])
+            if rows == 0:
+                print(self.content[self.display_mode])
+            else:
+                for i in self.content[self.display_mode].split('\n')[:rows+4]:
+                    print(i)
+
                 
 
     def activate(self, simple_content, detailed_content):
@@ -55,14 +60,14 @@ class Printer():
                 what = obj['what']
                 if what == 'detial':
                     self.toggle_display_mode()
-                    self._refresh()
+                    self._refresh(obj['rows'])
                 # TODO
                 if what == 'debug':
                     pass
                     
             elif msg_type == 'new_content':
                 self.activate(obj['simple'], obj["detailed"])
-                self._refresh()
+                self._refresh(obj['rows'])
                 if self.log:
                     self.log.write(self.content[self.display_mode])
                     self.log.write('\n')


### PR DESCRIPTION
According to the number of rows and columns of the terminal window, the number of displayed lines is dynamically adjusted, and if the terminal window size changes during the program running process, o2locktop dynamically adjusts the displayed number of lines. And the -l parameters is still available.

In ‘detial’ mode, no extra information is displayed, but when saving log files, all information is saved.

Hide the cursor when displayed