### PR TITLE
fix the bug that py3 import err, add ocfs2 debug check, add test files

### DIFF
--- a/o2locktop
+++ b/o2locktop
@@ -150,10 +150,22 @@ def connection_test(nodes,mount_point):
                                        "check if the node in the command line has input errors\n")
             sys.exit(0) 
 
+def connection_ocfs2_debug_test(nodes):
+    assert(nodes != None and len(nodes) > 0)
+    for node in nodes:
+        if(False == util.is_kernel_ocfs2_fs_stats_enabled(node)):
+            util.eprint("\no2locktop: error: the node({0}) do not support ocfs2 debug, please cheack and retry\n".format(node))
+            sys.exit(0)
+
 def local_test(mount_point):
     uuid = util.get_dlm_lockspace_mp(None, mount_point)    
     if not uuid:
         util.eprint("\no2locktop: error: can't find the mount point: {0}, please cheack and retry\n".format(mount_point))
+        sys.exit(0)
+
+def local_ocfs2_debug_test():
+    if(False == util.is_kernel_ocfs2_fs_stats_enabled()):
+        util.eprint("\no2locktop: error: the node({0}) do not support ocfs2 debug, please cheack and retry\n".format("localhost"))
         sys.exit(0)
 
 def main():
@@ -167,12 +179,14 @@ def main():
         mount_host, mount_point = args["mount_node"], args["mount_point"]
         nodes = args["node_list"]
         connection_test(nodes, mount_point)
+        connection_ocfs2_debug_test(nodes)
         lock_space_str = util.get_dlm_lockspace_mp(mount_host, mount_point)
         max_sys_inode_num = util.get_dlm_lockspace_max_sys_inode_number(mount_host, mount_point)
         mount_info = ':'.join([mount_host, mount_point])
     elif args['mode'] == "local":
         mount_point = args["mount_point"]
         local_test(mount_point)
+        local_ocfs2_debug_test()
         lock_space_str = util.get_dlm_lockspace_mp(None, mount_point)
         max_sys_inode_num = util.get_dlm_lockspace_max_sys_inode_number(None, mount_point)
         mount_info = mount_point

--- a/o2locktoplib/cat.py
+++ b/o2locktoplib/cat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #-*- coding: utf-8 -*-
 
-import util
+from o2locktoplib import util
 
 
 def gen_cat(which, lock_space, *args):

--- a/o2locktoplib/dlm.py
+++ b/o2locktoplib/dlm.py
@@ -3,15 +3,15 @@
 
 
 from multiprocessing.dummy import Pool as ThreadPool
-import cat
 import sys
 import signal
 import threading
-import util
-import config
-import keyboard
 import time
 import os
+from o2locktoplib import util
+from o2locktoplib import config
+from o2locktoplib import keyboard
+from o2locktoplib import cat
 
 # cat  -----  output of one time execution of "cat locking_stat"
                 # one cat contains multiple Shot(es)

--- a/o2locktoplib/keyboard.py
+++ b/o2locktoplib/keyboard.py
@@ -7,8 +7,8 @@ import select
 import signal
 import threading
 import time
-from retry import retry
-import config
+from o2locktoplib.retry import retry
+from o2locktoplib import config
 
 oldterm = None
 oldflags = None

--- a/o2locktoplib/printer.py
+++ b/o2locktoplib/printer.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 #-*- coding: utf-8 -*-
 
-import util
 import multiprocessing
-import config
-import keyboard
-from retry import retry
+from o2locktoplib import util
+from o2locktoplib import config
+from o2locktoplib import keyboard
+from o2locktoplib.retry import retry
 
 SIMPLE_DISPLAY=0
 DETAILED_DISPLAY=1

--- a/o2locktoplib/util.py
+++ b/o2locktoplib/util.py
@@ -34,9 +34,11 @@ def is_kernel_ocfs2_fs_stats_enabled(ip=None):
     uname = uname_r(ip)
     prefix = "ssh root@{0} ".format(ip) if ip else ""
     cmd = "grep \"CONFIG_OCFS2_FS_STATS=y\" /boot/config-{uname}".format(
-                uname=uname)
+                uname=" ".join(uname))
     sh = shell.shell(prefix + cmd)
     ret = sh.output()
+    if len(ret) == 0:
+        return False
     if ret[0] == "CONFIG_OCFS2_FS_STATS=y":
         return True
     return False

--- a/o2locktoplib/util.py
+++ b/o2locktoplib/util.py
@@ -4,13 +4,13 @@
 from __future__ import print_function
 import datetime
 import time
-import shell
 import pdb
 import os
 import sys
 import signal
-import config
 import socket
+from o2locktoplib import config
+from o2locktoplib import shell
 
 PY2 = (sys.version_info[0] == 2)
 

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,0 +1,5 @@
+test_local = True
+mount_point = '/mnt/shared'
+test_remote = True
+node_lists = []
+

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -1,0 +1,12 @@
+from o2locktoplib import cat
+import o2locktoplib.util as util
+import config
+
+def test_gen_cat():
+    if config.test_local:
+        if config.mount_point == "" or config.mount_point == None:
+            assert 0
+        else:
+            lock_space = util.get_dlm_lockspace_mp(None, config.mount_point)
+            print(len(cat.gen_cat('local', lock_space).get()))
+            assert len(cat.gen_cat('local', lock_space).get()) > 0 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,58 @@
+import os
+from o2locktoplib import util
+import config
+import pytest
+
+
+
+def test_get_hostname():
+    with os.popen('hostname') as fp:
+        hostname = fp.read()
+    assert hostname.strip() == util.get_hostname(), "get_hostname test faild"
+
+
+def test_uname_r():
+    with os.popen('uname -r') as fp:
+        uname_r = fp.read()
+    for i, j in zip(uname_r.strip().split(), util.uname_r()):
+        assert i == j, "uname_r test faild in local branch"
+    for i, j in zip(uname_r.strip().split(), util.uname_r('127.0.0.1')):
+        assert i == j, "uname_r test faild in remote branch"
+    
+def test_is_kernel_ocfs2_fs_stats_enabled():
+    with os.popen('grep "CONFIG_OCFS2_FS_STATS=y" /boot/config-$(uname -r)') as fp:
+        ocfs_debuf_enable = fp.read()
+    if ocfs_debuf_enable.strip() == "":
+        assert util.is_kernel_ocfs2_fs_stats_enabled() == False, "is_kernel_ocfs2_fs_stats_enabled test faild"
+    else:
+        assert util.is_kernel_ocfs2_fs_stats_enabled() == True, "is_kernel_ocfs2_fs_stats_enabled test faild"
+
+def test_get_dlm_lockspace_mp():
+    if config.mount_point == "" or config.mount_point == None:
+        assert 0, "you must give a value of mount_point in file config.py"
+    lockspace = util.get_dlm_lockspace_mp(None, config.mount_point)
+    with os.popen("o2info --volinfo {0} | grep UUID".format(config.mount_point)) as fp:
+        UUID = fp.read()
+    if UUID.strip() == "":
+        assert lockspace == None, "get_dlm_lockspace_mp test faild"
+    else:
+        assert UUID.strip().split()[1] == lockspace, "get_dlm_lockspace_mp test faild"
+
+@pytest.fixture
+def lockspace():
+    print('--------------------------------------------------------')
+    return util.get_dlm_lockspace_mp(None, config.mount_point)
+
+def test_get_one_cat(lockspace):
+    cat_ret = util.get_one_cat(lockspace)
+    with os.popen('"cat /sys/kernel/debug/ocfs2/{lockspace}/locking_state".format(lockspace=lockspace)') as fp:
+        cat_cmd_ret = fp.read()
+    if cat_cmd_ret.strip() == "":
+        assert cat_cmd_ret == "", "get_one_cat test faild"
+    else:
+        assert cat_ret == cat_cmd_ret, "get_one_cat test faild"
+
+
+def test_trans_uuid():
+    assert "daf3f5b6-f1c0-4b15-b9ed-8faaf109e895" == util._trans_uuid("DAF3F5B6F1C04B15B9ED8FAAF109E895"), "get_one_cat test faild" 
+    assert None == util._trans_uuid(""), "get_one_cat test faild in None branch" 


### PR DESCRIPTION
because python3 support absolute import only, but python2 support
absolute import & relative import, the previous code not work well on
python3. now I change the scripts, so they work well on both py2 & py3.

befor run the script, cheack if the ocfs2 debug enable, if disable, we can not read the source infomation.
add test files, for future automated test

