### PR TITLE
fix the bug that can't restore terminal when after using ctrl+z and fg

### DIFF
--- a/o2locktop
+++ b/o2locktop
@@ -9,6 +9,7 @@ import argparse
 import multiprocessing
 import os
 import time
+import signal
 
 attempt = 0
 while True:
@@ -18,6 +19,7 @@ while True:
         from o2locktoplib import printer
         from o2locktoplib import keyboard
         from o2locktoplib import config
+        from o2locktoplib.retry import retry
         break
     except ImportError as e:
         if attempt:
@@ -169,6 +171,10 @@ def local_ocfs2_debug_test():
         sys.exit(0)
 
 def main():
+    @retry(10)
+    def sigcont_handler(signum, frame):
+        keyboard.set_terminal()
+
     args = parse_args()
     log = args["log"]
     display_len = args["display_len"] 
@@ -210,6 +216,7 @@ def main():
     printer_process.start()
     lock_space_process.start()
 
+    signal.signal(signal.SIGCONT, sigcont_handler)
     keyboard.worker(printer_queue)
 
     lock_space_process.terminate()

--- a/o2locktoplib/keyboard.py
+++ b/o2locktoplib/keyboard.py
@@ -14,6 +14,19 @@ oldterm = None
 oldflags = None
 fd = sys.stdin.fileno()
 
+def set_terminal():
+    global oldterm,oldflags
+    oldterm = termios.tcgetattr(fd)
+    oldflags = fcntl.fcntl(fd, fcntl.F_GETFL)
+
+    newattr = termios.tcgetattr(fd)
+    newattr[3] = newattr[3] & ~termios.ICANON
+    newattr[3] = newattr[3] & ~termios.ECHO
+    termios.tcsetattr(fd, termios.TCSANOW, newattr)
+
+    fcntl.fcntl(fd, fcntl.F_SETFL, oldflags | os.O_NONBLOCK)
+    os.system('setterm -cursor off')
+
 class Keyboard():
     def __init__(self):
         pass
@@ -25,18 +38,7 @@ class Keyboard():
         return c
 
     def run(self, printer_queue):
-        global oldterm,oldflags
-        oldterm = termios.tcgetattr(fd)
-        oldflags = fcntl.fcntl(fd, fcntl.F_GETFL)
-
-        newattr = termios.tcgetattr(fd)
-        newattr[3] = newattr[3] & ~termios.ICANON
-        newattr[3] = newattr[3] & ~termios.ECHO
-        termios.tcsetattr(fd, termios.TCSANOW, newattr)
-
-        fcntl.fcntl(fd, fcntl.F_SETFL, oldflags | os.O_NONBLOCK)
-        os.system('setterm -cursor off')
-
+        set_terminal()
         while True:
             try:
                 c = self._getchar()

--- a/tests/config.py
+++ b/tests/config.py
@@ -1,5 +1,3 @@
-test_local = True
+mode = ['local', 'remote']
 mount_point = '/mnt/shared'
-test_remote = True
-node_lists = []
 

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -1,12 +1,42 @@
+import pytest
 from o2locktoplib import cat
 import o2locktoplib.util as util
 import config
 
-def test_gen_cat():
-    if config.test_local:
+@pytest.fixture
+def lockspace():
+    print('-----------------------------------------------')
+    return util.get_dlm_lockspace_mp(None, config.mount_point)
+
+@pytest.fixture(params = config.mode)
+def mode(request):
+    return request.param
+
+def test_gen_cat(lockspace, mode):
+    if mode == 'local':
         if config.mount_point == "" or config.mount_point == None:
-            assert 0
+            assert 0, "test get_cat remote mode faild"
         else:
-            lock_space = util.get_dlm_lockspace_mp(None, config.mount_point)
-            print(len(cat.gen_cat('local', lock_space).get()))
-            assert len(cat.gen_cat('local', lock_space).get()) > 0 
+            assert len(cat.gen_cat('local', lockspace).get()) > 0, "test get_cat remote mode faild" 
+    elif mode == 'remote':
+        if config.mount_point == "" or config.mount_point == None:
+            assert 0, "test get_cat remote mode faild"
+        else:
+            assert len(cat.gen_cat('local', lockspace).get()) > 0, "test get_cat remote mode faild" 
+
+
+def test_cat(lockspace, mode):
+    if mode == 'local':
+        if config.mount_point == "" or config.mount_point == None:
+            assert 0, "test LocalCat faild"
+        else:
+            cat_with_mode = cat.LocalCat(lockspace)
+            assert len(cat_with_mode.get()) > 0, "test LocalCat faild" 
+    elif mode == 'remote':
+        if config.mount_point == "" or config.mount_point == None:
+            assert 0, "test SshCat faild"
+        else:
+            cat_with_mode = cat.SshCat(lockspace, '127.0.0.1')
+            assert len(cat.gen_cat('local', lockspace).get()) > 0, "test SshCat faild" 
+
+    

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,57 @@
+import pytest
+from o2locktoplib.retry import retry
+
+def test_retry():
+    a = 0
+    @retry(15)
+    def add_a():
+        nonlocal a
+        a += 1
+        raise Exception("test run time error")
+    with pytest.raises(Exception):
+        add_a()
+    assert a == 15, "decorator retry test faild"
+
+def test_retry_with_other_Exception():
+    a = 0
+    @retry(exceptions = ZeroDivisionError)
+    def add_a():
+        nonlocal a
+        a += 1
+        raise ZeroDivisionError("test run time error")
+    with pytest.raises(ZeroDivisionError):
+        add_a()
+    assert a == 10, "decorator retry test faild"
+
+def test_retry_with_out_delay():
+    a = 0
+    @retry(exceptions = ZeroDivisionError, delay = False)
+    def add_a():
+        nonlocal a
+        a += 1
+        raise ZeroDivisionError("test run time error")
+    with pytest.raises(ZeroDivisionError):
+        add_a()
+    assert a == 10, "decorator retry test faild"
+
+
+# a more flexibility way to test more parameters
+@pytest.fixture(params=[1,2,3,4,5,6,7,8,9,10,11,12])
+def value1(request):
+    return request.param
+
+@pytest.fixture(params=[True, False])
+def value2(request):
+    return request.param
+
+def test_retry_with_auto_params(value1, value2):
+    a = []
+    a.append(0)
+    @retry(value1, delay=value2)
+    def add_a():
+        #nonlocal a
+        a[0] += 1
+        raise Exception("test run time error")
+    with pytest.raises(Exception):
+        add_a()
+    assert a[0] == value1, "decorator retry test faild"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -27,6 +27,17 @@ def test_is_kernel_ocfs2_fs_stats_enabled():
     else:
         assert util.is_kernel_ocfs2_fs_stats_enabled() == True, "is_kernel_ocfs2_fs_stats_enabled test faild"
 
+def test_get_dlm_lockspaces():
+    lockspaces = util.get_dlm_lockspaces()
+    with os.popen("dlm_tool ls | grep ^name") as fp:
+        UUID = fp.read()
+    if UUID.strip() == "":
+        assert lockspaces == None, "get_dlm_lockspace test faild"
+    else:
+        assert len(UUID.strip().split('\n')) == len(lockspaces), "get_dlm_lockspace test faild"
+        for i, j in zip([lockspace.split()[1] for lockspace in (UUID.strip().split('\n'))], lockspaces):
+            assert i == j, "get_dlm_lockspace test faild"
+
 def test_get_dlm_lockspace_mp():
     if config.mount_point == "" or config.mount_point == None:
         assert 0, "you must give a value of mount_point in file config.py"
@@ -40,19 +51,21 @@ def test_get_dlm_lockspace_mp():
 
 @pytest.fixture
 def lockspace():
-    print('--------------------------------------------------------')
     return util.get_dlm_lockspace_mp(None, config.mount_point)
 
 def test_get_one_cat(lockspace):
     cat_ret = util.get_one_cat(lockspace)
-    with os.popen('"cat /sys/kernel/debug/ocfs2/{lockspace}/locking_state".format(lockspace=lockspace)') as fp:
+    with os.popen("cat /sys/kernel/debug/ocfs2/{lockspace}/locking_state".format(lockspace=lockspace)) as fp:
         cat_cmd_ret = fp.read()
     if cat_cmd_ret.strip() == "":
         assert cat_cmd_ret == "", "get_one_cat test faild"
     else:
-        assert cat_ret == cat_cmd_ret, "get_one_cat test faild"
+        for i, j in zip(cat_ret, cat_cmd_ret.split('\n')):
+            assert i == j, "get_one_cat test faild"
 
 
 def test_trans_uuid():
     assert "daf3f5b6-f1c0-4b15-b9ed-8faaf109e895" == util._trans_uuid("DAF3F5B6F1C04B15B9ED8FAAF109E895"), "get_one_cat test faild" 
     assert None == util._trans_uuid(""), "get_one_cat test faild in None branch" 
+
+


### PR DESCRIPTION
in the previous version, when we throwd the process to the backstage, and if we restore the process to front end by "fg", then we can't input q to exit the process. this commit fix the bug

and add some test