### PR TITLE
make the tool get the first screen useful data quick

### DIFF
--- a/o2locktoplib/dlm.py
+++ b/o2locktoplib/dlm.py
@@ -664,6 +664,7 @@ class LockSpace:
         self._lock_types = {}
         self.should_stop = False
         self._thread_list = []
+        self.first_run = True
         if node_name_list is None:
             # node name None means this is a local node
             self._nodes['local'] = Node(self, None)
@@ -699,9 +700,12 @@ class LockSpace:
                             'rows':config.ROWS}
                             )
             end = time.time()
-            new_interval = interval - (end - start)
-            if new_interval > 0:
-                util.sleep(new_interval)
+            if not self.first_run:
+                new_interval = interval - (end - start)
+                if new_interval > 0:
+                    util.sleep(new_interval)
+            else:
+                self.first_run = False
 
     @property
     def name(self):

--- a/o2locktoplib/util.py
+++ b/o2locktoplib/util.py
@@ -155,7 +155,8 @@ def lockspace_to_device(uuid, ip=None):
     Device => Id: 253,16  Uuid: 7635D31F539A483C8E2F4CC606D5D628  Gen: 0x6434F530  Label:
     """
     dev_major, dev_minor = output[0].split()[3].split(",")
-    cmd = "lsblk -o MAJ:MIN,KNAME,MOUNTPOINT -l | grep '{major}:{minor}'" \
+    # the space must be required
+    cmd = "lsblk -o MAJ:MIN,KNAME,MOUNTPOINT -l | grep '{major}:{minor} '" \
                 .format(major=dev_major,minor=dev_minor)
     sh = shell.shell(prefix + cmd)
     #before grep output should be like


### PR DESCRIPTION
when we first start the tool, and we have to wait 5s to get the useful date, this update make the tool refresh twice without interval, so we can get the useful data more quick

fix the bug that when we according the major and minor to find the mount point
for example:
when major is 8, minor is 1, so we use this command "lsblk -o MAJ:MIN,KNAME,MOUNTPOINT -l | grep '8:1" to get the mount point
but if there also have a disk whose major is 8, mino is 16, the we get the first disk is the 8:16 disk, this is not we want, so we changed the command, add a space after the comman