### PR TITLE
add py2 setuptools support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
-import setuptools
+from o2locktoplib import util
+if not util.PY2:
+    import setuptools
+else:
+    import distutils.core as setuptools
 from o2locktoplib import config
 import os
 


### PR DESCRIPTION
because python2 not support setuptools, wo we use distutils.core to replace setuptools