### PR TITLE
Fix the bug that -d parameter is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ optional arguments:
   -n NODE_IP         OCFS2 node IP address for ssh
   -o LOG_FILE        log path
   -l DISPLAY_LENGTH  number of lock records to display, the default is 15
-  -V, --version      the current version of o2locktop
+  -V, --version      print the current version of o2locktop and exit
   -d, --debug        show all the inode including the system inode number
 
 The average/maximal wait time for DLM lock acquisitions likely gives hints to

--- a/o2locktop
+++ b/o2locktop
@@ -264,6 +264,10 @@ def local_cmd_test():
 def main():
     args = parse_args()
 
+    # can also use dup2
+    tmp_stderr = TemporaryFile('w+t')
+    sys.stderr = tmp_stderr
+
     @retry(10)
     def sigcont_handler(signum, frame):
         keyboard.set_terminal()
@@ -304,10 +308,6 @@ def main():
 
     if args["mode"] == "local":
         nodes = None
-
-    # can also use dup2
-    tmp_stderr = TemporaryFile('w+t')
-    sys.stderr = tmp_stderr
 
     for p in process_list:
         p.join()

--- a/o2locktop
+++ b/o2locktop
@@ -178,13 +178,18 @@ def _connection_test_worker(node,mount_point,queue,pid):
     now = time.time()
     uuid = util.get_dlm_lockspace_mp(node, mount_point)
     if not uuid:
-        if (time.time()-now) > 20:
+        if (time.time()-now) > 5:
             util.eprint("\no2locktop: error: network connection to {0} failed\n".format(node))
             os.kill(pid,signal.SIGUSR1)
+            return
+        elif not util.is_passwdless_ssh_set(node):
+            util.eprint('\no2locktop: error: o2locktop uses the passwordless SSH to OCFS2 nodes as root. Set it up if not: \nssh-keygen; ssh-copy-id root@node1\n')
+            os.kill(pid,signal.SIGUSR1)
+            return
         else:
             util.eprint("\no2locktop: error: can't find the mount point: {0}, please cheack and retry\n".format(mount_point))
             os.kill(pid,signal.SIGUSR1)
-        sys.exit(0)
+            return
     queue.put(uuid)
 
 
@@ -267,7 +272,7 @@ def main():
     def sigusr1_handler(signum, frame):
         keyboard.reset_terminal()
         # util.eprint("\no2locktop: error: can't find the mount point: {0}, please cheack and retry\n".format(args["mount_point"]))
-        sys.exit(0)
+        os._exit(0)
 
     signal.signal(signal.SIGUSR1, sigusr1_handler)
 

--- a/o2locktoplib/config.py
+++ b/o2locktoplib/config.py
@@ -1,6 +1,6 @@
 VERSION = "o2locktop 1.0.9"
 VERSION_SETUP = "1.0.9"
-clear = True
+clear = False
 interval = 5
 del_unfreshed_node = False
 ROWS = 0

--- a/o2locktoplib/util.py
+++ b/o2locktoplib/util.py
@@ -19,6 +19,12 @@ if "linux" in platform.system().lower():
 else:
     LINUX = False
 
+def is_passwdless_ssh_set(ip):
+    prefix = "ssh -oBatchMode=yes root@{0} ".format(ip)
+    sh = shell.shell(prefix + "uname")
+    ret = sh.output()
+    return (len(ret) != 0)
+
 def get_remote_path(ip):
     prefix = "ssh root@{0} ".format(ip)
     cmd = "echo '$PATH'"
@@ -196,7 +202,7 @@ def get_dlm_lockspaces(ip=None):
     return None
 
 def get_dlm_lockspace_mp(ip, mount_point):
-    prefix = "ssh root@{0} ".format(ip) if ip else ""
+    prefix = "ssh -oBatchMode=yes -oConnectTimeout=6 root@{0} ".format(ip) if ip else ""
     cmd = "o2info --volinfo {0} | grep UUID".format(mount_point)
     sh = shell.shell(prefix + cmd)
     output = sh.output()

--- a/o2locktoplib/util.py
+++ b/o2locktoplib/util.py
@@ -227,9 +227,13 @@ def get_dlm_lockspace_max_sys_inode_number(ip, mount_point):
     else:
         return None
     # TODO:fix shell
-    prefix = "ssh root@{0} ".format(ip) if ip else ""
-    cmd = "debugfs.ocfs2 -R \"ls //\" {0}".format(filesystem)
-    output = shell.shell(prefix + cmd).output()
+    if ip != None:
+        prefix = "ssh root@{0} ".format(ip) if ip else ""
+        cmd = "'debugfs.ocfs2 -R \"ls //\" {0}'".format(filesystem)
+        output = shell.shell(prefix + cmd).output()
+    else:
+        cmd = "debugfs.ocfs2 -R \"ls //\" {0}".format(filesystem)
+        output = os.popen(cmd).readlines()
     if len(output) > 0:
         return int(output[-1].split()[0])
     return None


### PR DESCRIPTION
In the previous version, the -d parameter can't control if to show the system inode number, Now use -d can show the system inode, without -d, then the system inode will not be shown.